### PR TITLE
User count box

### DIFF
--- a/december.css
+++ b/december.css
@@ -29,6 +29,7 @@
 #qualitymenu .header-drop-link {padding-left: 8px;}
 #qualitymenu .header-drop-link:hover {text-decoration:none;color:#fff;background-color:#2a9fd6}
 #leftpane-inner {margin-left:-10px !important;}
+#usercount > .profile-box {display:none !important;}
 
 #addfromurl, #searchcontrol, #customembed, #playlistmanager {
     background-color: #272B30 !important;


### PR DESCRIPTION
The user count breakdown (mouseover user count bar has bad z-index). Since nobody cared about it so far, might aswell hide it.

<img width="315" height="169" alt="523532449-dd8ba680-cc59-4962-bb72-87c904143ba4" src="https://github.com/user-attachments/assets/079134c6-db12-4472-9f98-0751cf839aa3" />
