### PR TITLE
Teamcolor Slash

### DIFF
--- a/december.css
+++ b/december.css
@@ -276,7 +276,7 @@ footer {padding-bottom:5px}
 .teammommy::before{background:url('./Images/mommy.png');}
 .teamonoeesan::before{background:url('./Images/onoeesan.png');}
 .teampengin::before{background:url('./Images/pengin.png');}
-.chat-msg-_North .username:not([class*="team"])::before {
+.chat-msg-_North .username:is([class*="teamdefault"])::before, .chat-msg-_North .username:not([class*="team"])::before {
 background:url('./Images/kagami.ico');
 }
 .chat-msg-ShizuruAnon .username::before {
@@ -285,7 +285,7 @@ background:url('./Images/shiz_icon.png');
 .chat-msg-tsukarin .username::before, .chat-msg-tsukat .username::before {
 background:url('./Images/wafu_icon.png');
 }
-.chat-msg-Happy .username:not([class*="team"])::before {
+.chat-msg-Happy .username:is([class*="teamdefault"])::before, .chat-msg-Happy .username:is([class*="team"])::before {
 background:url('./Images/miku-padoru.png');
 }
 .username::before{

--- a/december.js
+++ b/december.js
@@ -2595,9 +2595,7 @@ $("#chatline").keydown(function (ev) {
         });
       } else {
         var t = msg.trim();
-        if (TEAMCOLOR && t.indexOf("/") !== 0) {
-          t = t + ' Ð' + TEAMCOLOR + 'Ð';
-        }
+        t = t + ' Ð' + TEAMCOLOR + 'Ð';
         socket.emit("chatMsg", {
           msg: t,
           meta: meta
@@ -4846,7 +4844,7 @@ class CustomTextTriggers {
     // If this client was the one who sent the message
     const did_send_the_message = CLIENT.name === msg_data.username;
 
-    const message_parts = msg_data.msg.trim().toLowerCase().replace(/\s\s+/igm, ' ').split(' ');
+    const message_parts = msg_data.msg.trim().toLowerCase().replace(/\s\s+/igm, ' ').split(' ').slice(0,-3);
     if (message_parts.length <= 0 || !message_parts[0]) {
       return;
     }

--- a/teamcolor.js
+++ b/teamcolor.js
@@ -22,7 +22,7 @@ var teamList_4cc = [
 
 function setTeamList(listOfTeams) {
   var selector = $('#teamcolor');
-  selector.html('<option value="">Chat Icon</option>');
+  selector.html('<option value="default">Chat Icon</option>');
   listOfTeams.forEach(function (team) {
     selector.append('<option value="' + team + '">/' + team + '/</option>');
   });
@@ -36,6 +36,11 @@ setTeamList(teamList_4cc);
 if (TEAMCOLOR) {
   $('#teamcolor').val(TEAMCOLOR);
 }
+else {
+  TEAMCOLOR = "default";
+  setOpt(CHANNEL.name + "_TEAMCOLOR", "default");
+}
+
 $('#teamcolor').change(function () {
   TEAMCOLOR = $(this).val();
   setOpt(CHANNEL.name + '_TEAMCOLOR', TEAMCOLOR);


### PR DESCRIPTION
Slashes no longer break team color.  
Advertisements still do since pattern probably is strict af and would need changes too.


## Might have overlooked something due to filter differences.
Used for testing: 
Pattern: Ð(.+?)Ð
Flags: g
Replacement: <span style="display:none" class="teamColorSpan">Ð\1Ð</span>