### PR TITLE
Banri disable

### DIFF
--- a/december.js
+++ b/december.js
@@ -4507,7 +4507,7 @@ class GhostBanriEffect {
       GhostBanriEffect.banri_timeout = null;
     }
 
-    if (!state.user_enabled) {
+    if (!state.user_enabled || !state.is_running) {
       return;
     }
 
@@ -4559,7 +4559,7 @@ class GhostBanriEffect {
     }
 
     GhostBanriEffect.deactivate_timeout = setTimeout(() => {
-      GhostBanriEffect.disable();
+      GhostBanriEffect.stop();
     }, state.length_minutes * 60 * 1000);
   }
 }


### PR DESCRIPTION
Fix for Banri stop. If it stopped while it's shown, it restarts after it disappears.
Banri disabled itself on stop. Now it stops so it can be run again.
