### PR TITLE
Soundboard stop

### DIFF
--- a/december.js
+++ b/december.js
@@ -5567,7 +5567,7 @@ class SoundBoardEffect {
   static stopAll() {
     const state = SoundBoardEffect.state;
     for (const sound of state.active_sounds.values()) {
-      sound.stop();
+      sound.muted = true;
     }
   }
 


### PR DESCRIPTION
sound.stop is not a function

Pause would be the only alternative but don't feel like touching the "ended" event handler.